### PR TITLE
Using the argparse library and a couple squashed issues

### DIFF
--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -74,18 +74,18 @@ if(file.exists(paste0(trancepdir,"/TCS_MSA_PAAC.R"))){
 }else{
     source(paste0(trancepdir,"/src/TCS_MSA_PAAC.R"))
 }
-
+# load date
 load(paste0(trancepdir,"/tranCEP.rda"))
 
 MSA_TCS_PAAC(testname,test_fasta)
 
 testfeatuers = read.csv(paste0(compostions,testname,"_MSA_TCS_PAAC.csv"),sep=",")[,c(-1,-2)]
-svm.predtest<-predict(svm.fit,testfeatuers, probability=T)
-substateName<- substates[svm.predtest]
-seqs<- readFASTA(test_fasta)
-probabilities<- attr(svm.predtest,"probabilities")
-colnames(probabilities)<- paste(substates,"probability")
-names(seqs)<- sub("\\|.*","",sub(".+?\\|","", names(seqs)) )
+svm.predtest <- predict(svm.fit,testfeatuers, probability=T)
+substateName <- substates[svm.predtest]
+seqs <- readFASTA(test_fasta)
+probabilities <- attr(svm.predtest,"probabilities")
+colnames(probabilities) <- paste(substates,"probability")
+names(seqs) <- sub("\\|.*","",sub(".+?\\|","", names(seqs)) )
 print(paste0( "TranCEP output is found at: ", resultspath, "TranCEPout.csv"))
 
 write.csv(cbind(names(seqs),Prediction=substateName, Probabilities=probabilities ),paste0(resultspath,"TranCEPout.csv"))

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -101,7 +101,7 @@ wd=normalizePath(path.expand(".")) # change the the tool directory
 if (isAbsolutePath(db)){
     dbpath <- db
 }else{
-    dbpath <- paste0(TooTSCdir, db)
+    dbpath <- paste0(trancepdir, db)
 }
 
 compostions=paste0(trancepdir,"/Compositions/")

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -6,6 +6,7 @@
 ## output: The predicted class of each protein sequence, and the classes probabilities in csv format
 ## Author: Munira Alballa
 ##################################################
+install.packages("argparse")
 library(argparse)
 
 trancepdir <- "."

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -16,9 +16,6 @@ library(e1071)
 library(caret)
 library(R.utils)
 
-trancepdir <- "."
-db<- "./db/"
-
 parser <- ArgumentParser()
 
 # positional/ mandatory argument

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -81,6 +81,8 @@ out <- args$out
 db <- normalizePath(args$db)
 trancepdir <- normalizePath(args$trancepdir)
 
+# get directory of the script currently running
+script.dir <- dirname(sys.frame(1)$ofile)
 
 
 test_fasta <- normalizePath(path.expand(query))
@@ -113,7 +115,14 @@ substates<- c("amino",    "anion" ,   "cation"  , "electron", "other" ,   "prote
 
 
 #testing data with unknown substrates
-source(paste0(trancepdir,"/TCS_MSA_PAAC.R"))
+
+if(file.exists(paste0(trancepdir,"/TCS_MSA_PAAC.R"))){
+    source(paste0(trancepdir,"/TCS_MSA_PAAC.R"))
+}
+else{
+    source(paste0(script.dir,"/TCS_MSA_PAAC.R"))
+}
+
 load(paste0(trancepdir,"/tranCEP.rda"))
 
 MSA_TCS_PAAC(testname,test_fasta)

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -16,8 +16,16 @@ library(e1071)
 library(caret)
 library(R.utils)
 
-parser <- ArgumentParser()
+# load TCS_MSA_PAAC.R
+# try in trancepdir/src/ if the script is not found in trancepdir 
+if(file.exists(paste0(trancepdir,"/TCS_MSA_PAAC.R"))){
+    source(paste0(trancepdir,"/TCS_MSA_PAAC.R"))
+}else{
+    source(paste0(trancepdir,"/src/TCS_MSA_PAAC.R"))
+}
 
+
+parser <- ArgumentParser()
 # positional/ mandatory argument
 parser$add_argument("-query",default="",
                     help="The sequence input file in fasta format.",
@@ -41,19 +49,13 @@ db <- normalizePath(args$db)
 trancepdir <- normalizePath(args$trancepdir)
 
 
-if (isAbsolutePath(db)){
-    dbpath <- db
-}else{
-    dbpath <- paste0(trancepdir, db)
-}
-
 test_fasta <- normalizePath(path.expand(query))
 resultspath <- paste0(normalizePath(path.expand(out)),"/")
 
 
 wd=normalizePath(path.expand(".")) # working directory
 
-# create necessary directory
+# create necessary compositions directory
 compostions=paste0(trancepdir,"/Compositions/")
 intermediateFiles=paste0(trancepdir,"/output/")
 dir.create(compostions, showWarnings = FALSE, recursive = FALSE, mode = "0777")
@@ -64,16 +66,10 @@ substates<- c("amino",    "anion" ,   "cation"  , "electron", "other" ,   "prote
 
 
 #testing data with unknown substrates
-
-# try in trancepdir/src/ if the script is not found in trancepdir 
-if(file.exists(paste0(trancepdir,"/TCS_MSA_PAAC.R"))){
-    source(paste0(trancepdir,"/TCS_MSA_PAAC.R"))
-}else{
-    source(paste0(trancepdir,"/src/TCS_MSA_PAAC.R"))
-}
-# load date
+# load data
 load(paste0(trancepdir,"/tranCEP.rda"))
 
+# run MSA_TCS_PAAC
 MSA_TCS_PAAC(testname,test_fasta)
 
 testfeatuers = read.csv(paste0(compostions,testname,"_MSA_TCS_PAAC.csv"),sep=",")[,c(-1,-2)]
@@ -83,6 +79,7 @@ seqs <- readFASTA(test_fasta)
 probabilities <- attr(svm.predtest,"probabilities")
 colnames(probabilities) <- paste(substates,"probability")
 names(seqs) <- sub("\\|.*","",sub(".+?\\|","", names(seqs)) )
+
 print(paste0( "TranCEP output is found at: ", resultspath, "TranCEPout.csv"))
 
 write.csv(cbind(names(seqs),Prediction=substateName, Probabilities=probabilities ),paste0(resultspath,"TranCEPout.csv"))

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -118,8 +118,7 @@ substates<- c("amino",    "anion" ,   "cation"  , "electron", "other" ,   "prote
 # try in trancepdir/src/ if the script is not found in trancepdir 
 if(file.exists(paste0(trancepdir,"/TCS_MSA_PAAC.R"))){
     source(paste0(trancepdir,"/TCS_MSA_PAAC.R"))
-}
-else{
+}else{
     source(paste0(trancepdir,"/src/TCS_MSA_PAAC.R"))
 }
 

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -82,7 +82,6 @@ db <- normalizePath(args$db)
 trancepdir <- normalizePath(args$trancepdir)
 
 # get directory of the script currently running
-script.dir <- dirname(sys.frame(1)$ofile)
 
 
 test_fasta <- normalizePath(path.expand(query))
@@ -116,11 +115,12 @@ substates<- c("amino",    "anion" ,   "cation"  , "electron", "other" ,   "prote
 
 #testing data with unknown substrates
 
+# try in trancepdir/src/ if the script is not found in trancepdir 
 if(file.exists(paste0(trancepdir,"/TCS_MSA_PAAC.R"))){
     source(paste0(trancepdir,"/TCS_MSA_PAAC.R"))
 }
 else{
-    source(paste0(script.dir,"/TCS_MSA_PAAC.R"))
+    source(paste0(trancepdir,"/src/TCS_MSA_PAAC.R"))
 }
 
 load(paste0(trancepdir,"/tranCEP.rda"))

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -7,6 +7,14 @@
 ## Author: Munira Alballa
 ##################################################
 library(argparse)
+require(seqinr)
+library("Biostrings")
+library("stringr")
+require(protr)
+library(ISLR)
+library(e1071)
+library(caret)
+library(R.utils)
 
 trancepdir <- "."
 db<- "./db/"
@@ -25,53 +33,7 @@ parser$add_argument("-trancepdir", default='.',
                     metavar="DIRECTORY")
 parser$add_argument("-db", default="./db/",
                     help="The directory where the database is located. Default [%(default)].", metavar="DIRECTORY")
-
-args <- parser$parse_args()
-
-# args <- commandArgs(trailingOnly=TRUE)
-
-# terminate <- FALSE
-
-# out <- "."
-# trancepdir <- "."
-# db<- "./db/"
-
-# for(i in args){
-#    arg = strsplit(i, "=")[[1]];
-
-#    switch(arg[1],
-#      "-query"={
-#        query <- arg[2]
-#      },
-#      "-out"={
-#        out <- arg[2]
-#      },
-#      "-trancepdir"={
-#        trancepdir <- normalizePath(arg[2])
-#      },
-#      "-db"={
-#          db <- normalizePath(arg[2])
-#      },
-#      "-help"={
-#        cat("TranCEP v1.0 (April 2018)\n")
-#        cat("https://doi.org/10.1101/293159\n")
-#        cat("\n")
-#        cat("Usage: TranCEP -query=<input> [-trancepdir=<trancepdir>] [-out=<outdir>] [-db=<database directory>]\n")
-#        cat("\n")
-#        cat("\t<input> is your sequence input file in fasta format\n")
-#        cat("\t<out> is the output directory where you want the predicted results, formatted as csv\n")
-#        cat("\t\t<out> defaults to '",out,"'\n")
-#        cat("\t<trancepdir> is the directory where the base TranCEP files are located")
-#        cat("\t\t<trancepdir> defaults to '",trancepdir,"'\n")
-#        cat("\t\t <db> is the directory where the database is located.")
-#        cat("\t\t <db> defaults to ", paste0(trancepdir, "/db/"),"\n")
-#        cat("\n")
-#        terminate <- TRUE
-#        break
-#      }
-#    )
-# }
-
+args <- parser$parse_args() #start the parser
 if(args$query == ""){
   stop("Please input a query file (using -query=path/to/fasta_file).")
 }
@@ -81,22 +43,6 @@ out <- args$out
 db <- normalizePath(args$db)
 trancepdir <- normalizePath(args$trancepdir)
 
-# get directory of the script currently running
-
-
-test_fasta <- normalizePath(path.expand(query))
-resultspath <- paste0(normalizePath(path.expand(out)),"/")
-
-require(seqinr)
-library("Biostrings")
-library("stringr")
-require(protr)
-library(ISLR)
-library(e1071)
-library(caret)
-library(R.utils)
-wd=normalizePath(path.expand(".")) # change the the tool directory
-
 
 if (isAbsolutePath(db)){
     dbpath <- db
@@ -104,11 +50,18 @@ if (isAbsolutePath(db)){
     dbpath <- paste0(trancepdir, db)
 }
 
+test_fasta <- normalizePath(path.expand(query))
+resultspath <- paste0(normalizePath(path.expand(out)),"/")
+
+
+wd=normalizePath(path.expand(".")) # working directory
+
+# create necessary directory
 compostions=paste0(trancepdir,"/Compositions/")
 intermediateFiles=paste0(trancepdir,"/output/")
-
 dir.create(compostions, showWarnings = FALSE, recursive = FALSE, mode = "0777")
 testname="test"
+
 #dir.create(paste0(compostions,testname,"/"), showWarnings = TRUE, recursive = FALSE, mode = "0777") # intermediate files go here
 substates<- c("amino",    "anion" ,   "cation"  , "electron", "other" ,   "protein" ,"sugar" )
 
@@ -134,5 +87,6 @@ probabilities<- attr(svm.predtest,"probabilities")
 colnames(probabilities)<- paste(substates,"probability")
 names(seqs)<- sub("\\|.*","",sub(".+?\\|","", names(seqs)) )
 print(paste0( "TranCEP output is found at: ", resultspath, "TranCEPout.csv"))
+
 write.csv(cbind(names(seqs),Prediction=substateName, Probabilities=probabilities ),paste0(resultspath,"TranCEPout.csv"))
 

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -1,104 +1,132 @@
 #! /usr/bin/Rscript
-
+# hello world~
 ###################################################
 ## Name: TranCEP.R
 ## input: fasta file containing the unknown/testing protein sequences
 ## output: The predicted class of each protein sequence, and the classes probabilities in csv format
 ## Author: Munira Alballa
 ##################################################
+library(argparse)
 
-args <- commandArgs(trailingOnly=TRUE)
-
-terminate <- FALSE
-
-out <- "."
 trancepdir <- "."
 db<- "./db/"
 
-for(i in args){
-   arg = strsplit(i, "=")[[1]];
+parser <- ArgumentParser()
 
-   switch(arg[1],
-     "-query"={
-       query <- arg[2]
-     },
-     "-out"={
-       out <- arg[2]
-     },
-     "-trancepdir"={
-       trancepdir <- normalizePath(arg[2])
-     },
-     "-db"={
-         db <- normalizePath(arg[2])
-     },
-     "-help"={
-       cat("TranCEP v1.0 (April 2018)\n")
-       cat("https://doi.org/10.1101/293159\n")
-       cat("\n")
-       cat("Usage: TranCEP -query=<input> [-trancepdir=<trancepdir>] [-out=<outdir>] [-db=<database directory>]\n")
-       cat("\n")
-       cat("\t<input> is your sequence input file in fasta format\n")
-       cat("\t<out> is the output directory where you want the predicted results, formatted as csv\n")
-       cat("\t\t<out> defaults to '",out,"'\n")
-       cat("\t<trancepdir> is the directory where the base TranCEP files are located")
-       cat("\t\t<trancepdir> defaults to '",trancepdir,"'\n")
-       cat("\t\t <db> is the directory where the database is located.")
-       cat("\t\t <db> defaults to ", paste0(trancepdir, "/db/"),"\n")
-       cat("\n")
-       terminate <- TRUE
-       break
-     }
-   )
+# positional/ mandatory argument
+parser$add_argument("-query",default="",
+                    help="The sequence input file in fasta format.",
+                    metavar="Query file (fasta file path)")
+parser$add_argument("-out", "-o", default='.', 
+                    help="Output directory where you want the predicted results, formatted as csv. Default [%(default)].",
+                    metavar="DIRECTORY")
+parser$add_argument("-trancepdir", default='.', 
+                    help="The directory where the base TranCEP files are located. Default [%(default)].",
+                    metavar="DIRECTORY")
+parser$add_argument("-db", default="./db/",
+                    help="The directory where the database is located. Default [%(default)].", metavar="DIRECTORY")
+
+
+
+args <- parser$parse_args()
+
+# args <- commandArgs(trailingOnly=TRUE)
+
+# terminate <- FALSE
+
+# out <- "."
+# trancepdir <- "."
+# db<- "./db/"
+
+# for(i in args){
+#    arg = strsplit(i, "=")[[1]];
+
+#    switch(arg[1],
+#      "-query"={
+#        query <- arg[2]
+#      },
+#      "-out"={
+#        out <- arg[2]
+#      },
+#      "-trancepdir"={
+#        trancepdir <- normalizePath(arg[2])
+#      },
+#      "-db"={
+#          db <- normalizePath(arg[2])
+#      },
+#      "-help"={
+#        cat("TranCEP v1.0 (April 2018)\n")
+#        cat("https://doi.org/10.1101/293159\n")
+#        cat("\n")
+#        cat("Usage: TranCEP -query=<input> [-trancepdir=<trancepdir>] [-out=<outdir>] [-db=<database directory>]\n")
+#        cat("\n")
+#        cat("\t<input> is your sequence input file in fasta format\n")
+#        cat("\t<out> is the output directory where you want the predicted results, formatted as csv\n")
+#        cat("\t\t<out> defaults to '",out,"'\n")
+#        cat("\t<trancepdir> is the directory where the base TranCEP files are located")
+#        cat("\t\t<trancepdir> defaults to '",trancepdir,"'\n")
+#        cat("\t\t <db> is the directory where the database is located.")
+#        cat("\t\t <db> defaults to ", paste0(trancepdir, "/db/"),"\n")
+#        cat("\n")
+#        terminate <- TRUE
+#        break
+#      }
+#    )
+# }
+
+if(args$query == ""){
+  stop("Please input a query file (using -query=path/to/fasta_file).")
 }
 
-if(!terminate) {
+query <- args$query
+out <- args$out
+db <- normalizePath(args$db)
+trancepdir <- normalizePath(args$trancepdir)
 
-    if(!exists("query")) {
-       stop("-query has not been passed")
-    }
 
-    test_fasta <- normalizePath(path.expand(query))
-    resultspath <- paste0(normalizePath(path.expand(out)),"/")
 
-    require(seqinr)
-    library("Biostrings")
-    library("stringr")
-    require(protr)
-    library(ISLR)
-    library(e1071)
-    library(caret)
-    library(R.utils)
-    wd=normalizePath(path.expand(".")) # change the the tool directory
-   
+test_fasta <- normalizePath(path.expand(query))
+resultspath <- paste0(normalizePath(path.expand(out)),"/")
 
-    if (isAbsolutePath(db)){
-        dbpath <- db
-    }else{
-        dbpath <- paste0(TooTSCdir, db)
-    }
+require(seqinr)
+library("Biostrings")
+library("stringr")
+require(protr)
+library(ISLR)
+library(e1071)
+library(caret)
+library(R.utils)
+wd=normalizePath(path.expand(".")) # change the the tool directory
 
-    compostions=paste0(trancepdir,"/Compositions/")
-    intermediateFiles=paste0(trancepdir,"/output/")
 
-    dir.create(compostions, showWarnings = TRUE, recursive = FALSE, mode = "0777")
-    testname="test"
+if (isAbsolutePath(db)){
+    dbpath <- db
+}else{
+    dbpath <- paste0(TooTSCdir, db)
+}
+
+compostions=paste0(trancepdir,"/Compositions/")
+intermediateFiles=paste0(trancepdir,"/output/")
+
+dir.create(compostions, showWarnings = TRUE, recursive = FALSE, mode = "0777")
+testname="test"
 #dir.create(paste0(compostions,testname,"/"), showWarnings = TRUE, recursive = FALSE, mode = "0777") # intermediate files go here
-    substates<- c("amino",    "anion" ,   "cation"  , "electron", "other" ,   "protein" ,"sugar" )
+substates<- c("amino",    "anion" ,   "cation"  , "electron", "other" ,   "protein" ,"sugar" )
 
 
 #testing data with unknown substrates
-    source(paste0(trancepdir,"/TCS_MSA_PAAC.R"))
-    load(paste0(trancepdir,"/tranCEP.rda"))
+source(paste0(trancepdir,"/TCS_MSA_PAAC.R"))
+load(paste0(trancepdir,"/tranCEP.rda"))
 
-    MSA_TCS_PAAC(testname,test_fasta)
+MSA_TCS_PAAC(testname,test_fasta)
 
-    testfeatuers = read.csv(paste0(compostions,testname,"_MSA_TCS_PAAC.csv"),sep=",")[,c(-1,-2)]
-    svm.predtest<-predict(svm.fit,testfeatuers, probability=T)
-    substateName<- substates[svm.predtest]
-    seqs<- readFASTA(test_fasta)
-    probabilities<- attr(svm.predtest,"probabilities")
-    colnames(probabilities)<- paste(substates,"probability")
-    names(seqs)<- sub("\\|.*","",sub(".+?\\|","", names(seqs)) )
-    print(paste0( "TranCEP output is found at: ", resultspath, "TranCEPout.csv"))
-    write.csv(cbind(names(seqs),Prediction=substateName, Probabilities=probabilities ),paste0(resultspath,"TranCEPout.csv"))
-}
+testfeatuers = read.csv(paste0(compostions,testname,"_MSA_TCS_PAAC.csv"),sep=",")[,c(-1,-2)]
+svm.predtest<-predict(svm.fit,testfeatuers, probability=T)
+substateName<- substates[svm.predtest]
+seqs<- readFASTA(test_fasta)
+probabilities<- attr(svm.predtest,"probabilities")
+colnames(probabilities)<- paste(substates,"probability")
+names(seqs)<- sub("\\|.*","",sub(".+?\\|","", names(seqs)) )
+print(paste0( "TranCEP output is found at: ", resultspath, "TranCEPout.csv"))
+write.csv(cbind(names(seqs),Prediction=substateName, Probabilities=probabilities ),paste0(resultspath,"TranCEPout.csv"))
+

--- a/src/TranCEPTool.R
+++ b/src/TranCEPTool.R
@@ -6,7 +6,6 @@
 ## output: The predicted class of each protein sequence, and the classes probabilities in csv format
 ## Author: Munira Alballa
 ##################################################
-install.packages("argparse")
 library(argparse)
 
 trancepdir <- "."
@@ -26,8 +25,6 @@ parser$add_argument("-trancepdir", default='.',
                     metavar="DIRECTORY")
 parser$add_argument("-db", default="./db/",
                     help="The directory where the database is located. Default [%(default)].", metavar="DIRECTORY")
-
-
 
 args <- parser$parse_args()
 
@@ -109,7 +106,7 @@ if (isAbsolutePath(db)){
 compostions=paste0(trancepdir,"/Compositions/")
 intermediateFiles=paste0(trancepdir,"/output/")
 
-dir.create(compostions, showWarnings = TRUE, recursive = FALSE, mode = "0777")
+dir.create(compostions, showWarnings = FALSE, recursive = FALSE, mode = "0777")
 testname="test"
 #dir.create(paste0(compostions,testname,"/"), showWarnings = TRUE, recursive = FALSE, mode = "0777") # intermediate files go here
 substates<- c("amino",    "anion" ,   "cation"  , "electron", "other" ,   "protein" ,"sugar" )


### PR DESCRIPTION
closes #8 #9 if I'm not mistaken. Tested and it runs. Now also no need cp `cp ./src .` because if TCS_MSA_PAAC.R is not in `trancepdir`  it checks in `trancepdir/src` for it. 